### PR TITLE
JacksonDataformatXML version bump

### DIFF
--- a/contribs/dependencies.lock
+++ b/contribs/dependencies.lock
@@ -83,7 +83,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -544,7 +544,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -1012,7 +1012,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -1536,7 +1536,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -1997,7 +1997,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -2458,7 +2458,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -3005,7 +3005,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -3552,7 +3552,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -4099,7 +4099,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]

--- a/jersey/dependencies.lock
+++ b/jersey/dependencies.lock
@@ -76,7 +76,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -475,7 +475,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -884,7 +884,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -1346,7 +1346,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -1745,7 +1745,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -2144,7 +2144,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -2575,7 +2575,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -3006,7 +3006,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -3437,7 +3437,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]

--- a/server/dependencies.lock
+++ b/server/dependencies.lock
@@ -127,7 +127,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -1903,7 +1903,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -3679,7 +3679,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -5455,7 +5455,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -8299,7 +8299,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -10075,7 +10075,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -11851,7 +11851,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -13594,7 +13594,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -15392,7 +15392,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -17190,7 +17190,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -18988,7 +18988,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]

--- a/test-harness/dependencies.lock
+++ b/test-harness/dependencies.lock
@@ -219,7 +219,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -2185,7 +2185,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -4151,7 +4151,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]
@@ -6117,7 +6117,7 @@
             ]
         },
         "com.fasterxml.jackson.dataformat:jackson-dataformat-xml": {
-            "locked": "2.4.5",
+            "locked": "2.7.4",
             "transitive": [
                 "io.swagger:swagger-jaxrs"
             ]


### PR DESCRIPTION
JacksonDataformatXML version bump from 2.4.5 to 2.7.4 to address CVE-2016-3088